### PR TITLE
ADN data cURL examples must use content header

### DIFF
--- a/adnuntius-data/api-documentation/http/http-page-view.md
+++ b/adnuntius-data/api-documentation/http/http-page-view.md
@@ -49,7 +49,7 @@ POST https://data.adnuntius.com/page
 This is a very simple example, using [curl](https://curl.haxx.se), demonstrating how a page view is sent to Adnuntius Data.
 
 ```bash
-curl https://data.adnuntius.com/page -d '{
+curl -H "Content-Type: application/json" https://data.adnuntius.com/page -d '{
   "browserId": "123xyz",
   "folderId": "00000000000123ab",
   "keywords": ["sport", "tennis"],

--- a/adnuntius-data/api-documentation/http/http-profile.md
+++ b/adnuntius-data/api-documentation/http/http-profile.md
@@ -54,7 +54,7 @@ If the request is received correctly, an HTTP 200 status code will be returned. 
 This is a very simple example, using [curl](https://curl.haxx.se), demonstrating how a profile update is sent to Adnuntius Data.
 
 ```bash
-curl https://data.adnuntius.com/visitor -d '{
+curl -H "Content-Type: application/json" https://data.adnuntius.com/visitor -d '{
   "browserId": "123xyz",
   "folderId": "00000000000123ab",
   "profileValues": {
@@ -79,7 +79,7 @@ If the request is received correctly and the record successfully created or upda
 This is a very simple example, using [curl](https://curl.haxx.se), demonstrating how a synchronous profile update is sent to Adnuntius Data.
 
 ```bash
-curl https://data.adnuntius.com/synchronous/visitor -d '{
+curl -H "Content-Type: application/json" https://data.adnuntius.com/synchronous/visitor -d '{
   "browserId": "123xyz",
   "folderId": "00000000000123ab",
   "profileValues": {

--- a/adnuntius-data/sending-data/http/http-page-view.md
+++ b/adnuntius-data/sending-data/http/http-page-view.md
@@ -49,7 +49,7 @@ If the request is received correctly, an HTTP 200 status code will be returned.
 This is a very simple example, using [curl](https://curl.haxx.se), demonstrating how a page view is sent to Adnuntius Data.
 
 ```bash
-curl https://data.adnuntius.com/page -d '{
+curl -H "Content-Type: application/json" https://data.adnuntius.com/page -d '{
   "externalSystemType": "my_crm",
   "externalSystemUserId": "123hfy4658f",
   "networkId": "my_network",

--- a/adnuntius-data/sending-data/http/http-profile.md
+++ b/adnuntius-data/sending-data/http/http-profile.md
@@ -51,7 +51,7 @@ If the request is received correctly, an HTTP 200 status code will be returned. 
 This is a very simple example, using [curl](https://curl.haxx.se), demonstrating how a profile update is sent to Adnuntius Data.
 
 ```bash
-curl https://data.adnuntius.com/visitor -d '{
+curl -H "Content-Type: application/json" https://data.adnuntius.com/visitor -d '{
   "externalSystemType": "my_crm",
   "externalSystemUserId": "123hfy4658f",
   "networkId": "my_network",
@@ -77,7 +77,7 @@ If the request is received correctly and the record successfully created or upda
 This is a very simple example, using [curl](https://curl.haxx.se), demonstrating how a synchronous profile update is sent to Adnuntius Data.
 
 ```bash
-curl https://data.adnuntius.com/synchronous/visitor -d '{
+curl -H "Content-Type: application/json" https://data.adnuntius.com/synchronous/visitor -d '{
   "externalSystemType": "my_crm",
   "externalSystemUserId": "123hfy4658f",
   "networkId": "my_network",


### PR DESCRIPTION
The cURL examples for adn data won't work without
the -H "Content-Type: application/json" header.